### PR TITLE
Batch calls to srem

### DIFF
--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -169,7 +169,7 @@ def invalidate_model(model):
         cache_keys = redis_client.sunion(conjs_keys)
         redis_client.delete(*(list(cache_keys) + conjs_keys))
 
-        for batch in batcher(conjs_keys, 200):
+        for batch in batcher(conjs_keys, 1000):
             redis_client.srem(set_key, *batch)
 
 def invalidate_all():

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import six
 from cacheops.conf import redis_client, handle_connection_failure
-from cacheops.utils import get_model_name, non_proxy
+from cacheops.utils import get_model_name, non_proxy, batcher
 
 
 __all__ = ('invalidate_obj', 'invalidate_model', 'invalidate_all')
@@ -168,8 +168,9 @@ def invalidate_model(model):
     if conjs_keys:
         cache_keys = redis_client.sunion(conjs_keys)
         redis_client.delete(*(list(cache_keys) + conjs_keys))
-        for k in conjs_keys:
-            redis_client.srem(set_key, k)
+
+        for batch in batcher(conjs_keys, 200):
+            redis_client.srem(set_key, *batch)
 
 def invalidate_all():
     redis_client.flushdb()

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from operator import concat, itemgetter
-from itertools import product
+from itertools import product, islice, chain
 import inspect
 
 try:
@@ -32,6 +32,13 @@ except ImportError:
 
 
 LONG_DISJUNCTION = 8
+
+
+def batcher(iterable, size):
+    sourceiter = iter(iterable)
+    while True:
+        batchiter = islice(sourceiter, size)
+        yield chain([batchiter.next()], batchiter)
 
 
 def non_proxy(model):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -114,7 +114,7 @@ class BasicTests(BaseTestCase):
         with self.assertNumQueries(0):
             list(mb.labels.cache().all())
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             label = Label.objects.cache().create(text="Gateway")
 
         with self.assertNumQueries(2):
@@ -124,7 +124,6 @@ class BasicTests(BaseTestCase):
             list(mb.labels.cache().all())
         with self.assertNumQueries(0):
             list(mb.labels.cache().all())
-
 
     def test_db_column(self):
         e = Extra.objects.cache().get(tag=5)


### PR DESCRIPTION
During the outage yesterday Glenn noticed that there were a high number of calls to srem. This pipelines the request. Reducing the number of calls but not the number of objects being deleted. srem is called during a m2m invalidation.

```
1438039522.356948 [13 127.0.0.1:36865] "SREM" "conj:tests.label" "conj:tests.label:id=2"
1438039522.357004 [13 127.0.0.1:36865] "SREM" "conj:tests.label" "conj:tests.label:id=1"
```

is now

```
1438040579.482493 [13 127.0.0.1:37303] "SREM" "conj:tests.label" "conj:tests.label:id=2" "conj:tests.label:id=1"
```
